### PR TITLE
Approx. normalized movement by increasing player cardinal speed

### DIFF
--- a/src/data/object_events/movement_action_func_tables.h
+++ b/src/data/object_events/movement_action_func_tables.h
@@ -952,9 +952,11 @@ u8 (*const gMovementActionFuncs_FaceRight[])(struct ObjectEvent *, struct Sprite
 
 static u8 (*const sDirectionAnimFuncsBySpeed[])(u8) = {
     [MOVE_SPEED_NORMAL] = GetMoveDirectionAnimNum,
+    [MOVE_SPEED_NORMAL_2] = GetMoveDirectionAnimNum,
     [MOVE_SPEED_FAST_1] = GetMoveDirectionFastAnimNum,
     [MOVE_SPEED_FAST_2] = GetMoveDirectionFastAnimNum,
     [MOVE_SPEED_FASTER] = GetMoveDirectionFasterAnimNum,
+    [MOVE_SPEED_FASTER_2] = GetMoveDirectionFasterAnimNum,
     [MOVE_SPEED_FASTEST] = GetMoveDirectionFastestAnimNum,
 };
 

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -29,14 +29,17 @@
 #include "constants/mauville_old_man.h"
 #include "constants/trainer_types.h"
 #include "constants/union_room.h"
+#include "script.h"
 
 // this file was known as evobjmv.c in Game Freak's original source
 
 enum {
     MOVE_SPEED_NORMAL, // walking
+    MOVE_SPEED_NORMAL_2,
     MOVE_SPEED_FAST_1, // running / surfing / sliding (ice tile)
     MOVE_SPEED_FAST_2, // water current / acro bike
     MOVE_SPEED_FASTER, // mach bike's max speed
+    MOVE_SPEED_FASTER_2,
     MOVE_SPEED_FASTEST,
 };
 
@@ -165,6 +168,8 @@ static void DestroyLevitateMovementTask(u8);
 static bool8 NpcTakeStep(struct Sprite *);
 static bool8 IsElevationMismatchAt(u8, s16, s16);
 static bool8 AreElevationsCompatible(u8, u8);
+static u8 GetNormalizedSpeed(struct ObjectEvent *objectEvent, u8 direction, u8 speed);
+static inline u8 IsSpeedNormalized(struct ObjectEvent *objectEvent, u8 direction, u8 newSpeed);
 
 static const struct SpriteFrameImage sPicTable_PechaBerryTree[];
 
@@ -5226,7 +5231,7 @@ void InitNpcForMovement(struct ObjectEvent *objectEvent, struct Sprite *sprite, 
     SetObjectEventDirection(objectEvent, direction);
     MoveCoords(direction, &x, &y);
     ShiftObjectEventCoords(objectEvent, x, y);
-    SetSpriteDataForNormalStep(sprite, direction, speed);
+    SetSpriteDataForNormalStep(sprite, direction, GetNormalizedSpeed(objectEvent, direction, speed));
     sprite->animPaused = FALSE;
 
     if (sLockedAnimObjectEvents != NULL && FindLockedObjectEventIndex(objectEvent) != OBJECT_EVENTS_COUNT)
@@ -5251,17 +5256,31 @@ static void StartRunningAnim(struct ObjectEvent *objectEvent, struct Sprite *spr
     SetStepAnimHandleAlternation(objectEvent, sprite, GetRunningDirectionAnimNum(objectEvent->facingDirection));
 }
 
+#define sDir    data[3]
+#define sSpeed  data[4]
+
 static bool8 UpdateMovementNormal(struct ObjectEvent *objectEvent, struct Sprite *sprite)
 {
     if (NpcTakeStep(sprite))
     {
         ShiftStillObjectEventCoords(objectEvent);
         objectEvent->triggerGroundEffectsOnStop = TRUE;
-        sprite->animPaused = TRUE;
+        if (IsSpeedNormalized(objectEvent, sprite->sDir, sprite->sSpeed))
+        {
+            sprite->animPaused = FALSE;
+            sprite->animDelayCounter = max(0, sprite->animDelayCounter - 1);
+        }
+        else 
+        {
+            sprite->animPaused = TRUE;
+        }
         return TRUE;
     }
     return FALSE;
 }
+
+#undef sDir
+#undef sSpeed
 
 static void InitNpcForWalkSlow(struct ObjectEvent *objectEvent, struct Sprite *sprite, u8 direction)
 {
@@ -5295,6 +5314,30 @@ static bool8 UpdateWalkSlow(struct ObjectEvent *objectEvent, struct Sprite *spri
         return TRUE;
     }
     return FALSE;
+}
+
+#define IS_DIAGONAL(dir) ((dir) > DIR_EAST)
+
+static u8 GetNormalizedSpeed(struct ObjectEvent *objectEvent, u8 direction, u8 speed)
+{
+    if (!objectEvent->isPlayer || ArePlayerFieldControlsLocked())
+    {
+        return speed;
+    }
+
+    if (IS_DIAGONAL(direction)) 
+    {
+        return speed - (speed == MOVE_SPEED_FASTEST);
+    } 
+    else
+    {
+        return speed + (speed != MOVE_SPEED_FASTEST);
+    }
+}
+
+static inline bool8 IsSpeedNormalized(struct ObjectEvent *objectEvent, u8 direction, u8 speed)
+{
+    return GetNormalizedSpeed(objectEvent, direction, speed) != speed;
 }
 
 bool8 MovementAction_WalkSlowNorthwest_Step0(struct ObjectEvent *objectEvent, struct Sprite *sprite)
@@ -8402,6 +8445,12 @@ static void Step4(struct Sprite *sprite, u8 dir)
     sprite->y += 4 * (u16) sDirectionToVectors[dir].y;
 }
 
+static void Step6(struct Sprite *sprite, u8 dir)
+{
+    sprite->x += 6 * (u16) sDirectionToVectors[dir].x;
+    sprite->y += 6 * (u16) sDirectionToVectors[dir].y;
+}
+
 static void Step8(struct Sprite *sprite, u8 dir)
 {
     sprite->x += 8 * (u16) sDirectionToVectors[dir].x;
@@ -8439,6 +8488,21 @@ static const SpriteStepFunc sStep1Funcs[] = {
     Step1,
 };
 
+static const SpriteStepFunc sStep1_5Funcs[] = {
+    Step1,
+    Step2,
+    Step1,
+    Step1,
+    Step2,
+    Step1,
+    Step1,
+    Step2,
+    Step1,
+    Step1,
+    Step2,
+    Step1,
+};
+
 static const SpriteStepFunc sStep2Funcs[] = {
     Step2,
     Step2,
@@ -8466,6 +8530,12 @@ static const SpriteStepFunc sStep4Funcs[] = {
     Step4,
 };
 
+static const SpriteStepFunc sStep6Funcs[] = {
+    Step6,
+    Step4,
+    Step6,
+};
+
 static const SpriteStepFunc sStep8Funcs[] = {
     Step8,
     Step8,
@@ -8473,17 +8543,21 @@ static const SpriteStepFunc sStep8Funcs[] = {
 
 static const SpriteStepFunc *const sNpcStepFuncTables[] = {
     [MOVE_SPEED_NORMAL] = sStep1Funcs,
+    [MOVE_SPEED_NORMAL_2] = sStep1_5Funcs,
     [MOVE_SPEED_FAST_1] = sStep2Funcs,
     [MOVE_SPEED_FAST_2] = sStep3Funcs,
     [MOVE_SPEED_FASTER] = sStep4Funcs,
+    [MOVE_SPEED_FASTER_2] = sStep6Funcs,
     [MOVE_SPEED_FASTEST] = sStep8Funcs,
 };
 
 static const s16 sStepTimes[] = {
     [MOVE_SPEED_NORMAL] = ARRAY_COUNT(sStep1Funcs),
+    [MOVE_SPEED_NORMAL_2] = ARRAY_COUNT(sStep1_5Funcs),
     [MOVE_SPEED_FAST_1] = ARRAY_COUNT(sStep2Funcs),
     [MOVE_SPEED_FAST_2] = ARRAY_COUNT(sStep3Funcs),
     [MOVE_SPEED_FASTER] = ARRAY_COUNT(sStep4Funcs),
+    [MOVE_SPEED_FASTER_2] = ARRAY_COUNT(sStep6Funcs),
     [MOVE_SPEED_FASTEST] = ARRAY_COUNT(sStep8Funcs),
 };
 

--- a/tools/mapjson/json11.cpp
+++ b/tools/mapjson/json11.cpp
@@ -23,6 +23,7 @@
 #include <cstdlib>
 #include <cstdio>
 #include <limits>
+#include <cstdint>
 
 namespace json11 {
 


### PR DESCRIPTION
Approximately normalizes the player movement by speeding up the player movement when not moving diagonally. 

## Description
To normalize diagonal movement it would need to be slowed down by sqrt2 (1.414). However we can achieve a similar effect by making sure that the ratio between diagonal and cardinal movement speeds is always approximately sqrt2. In this case the ratio is always either 1.333 or 1.5 depending on original speed (so the error is around 0.08). 

- Two new movement speeds have been added MOVE_SPEED_NORMAL_2 and MOVE_SPEED_FASTER_2
Movement speeds are now NORMAL, NORMAL_2, FAST_1, FAST_2, FASTER, FASTER_2, FASTEST

- New step functions 12 steps and 6 steps have been added to allow good ratios for any speed. The ratio between any two consecutive steps should be approximately sqrt2. Sprite step functions now have steps 16, 12, 8, 6, 4, 3, 2 

- UpdateMovementNormal now updates speed to the normalized version. It will only do this to the player, as only they move diagonally. It will not effect player moment speed if the field controls are locked so the player will move the same speed as npc's in cutscenes. The players speed will be incremented in cardinal directions unless the player is already moving at the FASTEST speed, in which case it will be decremented on diagonals. 

- The new movement speeds reuse the existing Anim functions. UpdateMovementNormal has been updated to ensure the player still animates correctly at any speed.

- A missing import was added to json11.cpp that was preventing the project compiling

## Discord
kittypboxx

## Example
https://github.com/user-attachments/assets/4fbe19f4-d4bf-4023-a4ca-9e1564ab4a23


